### PR TITLE
修复bug，修改默认模板

### DIFF
--- a/aspnet-core/host/Lion.AbpSuite.HttpApi.Host/Dockerfile
+++ b/aspnet-core/host/Lion.AbpSuite.HttpApi.Host/Dockerfile
@@ -21,8 +21,8 @@ RUN echo "deb http://mirrors.aliyun.com/debian/ bullseye main non-free contrib" 
 # 设置工作目录
 WORKDIR /app
 
-# 暴露80端口
-EXPOSE 80
+# 暴露8080端口
+EXPOSE 8080
 # 设置时区 .net6 才有这个问题
 ENV TZ=Asia/Shanghai
 

--- a/aspnet-core/src/Lion.AbpSuite.DbMigrator/Dockerfile
+++ b/aspnet-core/src/Lion.AbpSuite.DbMigrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 
 # 创建目录
 RUN mkdir /app

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Application/{{aggregateCode}}AppService.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Application/{{aggregateCode}}AppService.txt
@@ -1,14 +1,15 @@
-using  Volo.Abp;
-using  Volo.Abp.Application.Dtos;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
-using  {{ context.Project.NameSpace }}.Application.Contracts;
+using Volo.Abp;
+using Volo.Abp.Application.Dtos;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
+using {{ context.Project.NameSpace }}.Application.Contracts;
 
 namespace {{ context.Project.NameSpace }}.Application;
 
 /// <summary>
 /// {{ context.EntityModel.Description }}
 /// </summary>
-public class {{ context.EntityModel.Code }}AppService : ApplicationService, I{{ context.EntityModel.Code }}AppService
+public partial class {{ context.EntityModel.Code }}AppService : ApplicationService, I{{ context.EntityModel.Code }}AppService
 {
     private readonly {{ context.EntityModel.Code }}Manager _{{ context.EntityModel.CodeCamelCase }}Manager;
 
@@ -16,7 +17,7 @@ public class {{ context.EntityModel.Code }}AppService : ApplicationService, I{{ 
     {
         _{{ context.EntityModel.CodeCamelCase }}Manager = {{ context.EntityModel.CodeCamelCase }}Manager;
     }
-    
+
     /// <summary>
     /// 分页查询{{ context.EntityModel.Description }}
     /// </summary>
@@ -37,14 +38,14 @@ public class {{ context.EntityModel.Code }}AppService : ApplicationService, I{{ 
     /// </summary>
     public Task CreateAsync(Create{{ context.EntityModel.Code }}Input input)
     {
-        return  _{{ context.EntityModel.CodeCamelCase }}Manager.CreateAsync(
-         GuidGenerator.Create() 
-         {{-  for prop in context.EntityModel.Properties -}}
-         {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
-         input.{{ prop.Code }}
-         {{- if for.last; "\r\n"; else; ; end ~}}
-         {{-  end ~}}
-				);
+        return _{{ context.EntityModel.CodeCamelCase }}Manager.CreateAsync(
+            GuidGenerator.Create() 
+        {{-  for prop in context.EntityModel.Properties -}}
+          {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
+            input.{{ prop.Code }}
+          {{- if for.last; "\r\n"; else; ; end ~}}
+        {{-  end ~}}
+			);
     }
 
     /// <summary>
@@ -52,14 +53,14 @@ public class {{ context.EntityModel.Code }}AppService : ApplicationService, I{{ 
     /// </summary>
     public Task UpdateAsync(Update{{ context.EntityModel.Code }}Input input)
     { 
-        return  _{{ context.EntityModel.CodeCamelCase }}Manager.UpdateAsync(
-         input.Id
-         {{-  for prop in context.EntityModel.Properties -}}
-         {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
-         input.{{ prop.Code }}
-         {{- if for.last; "\r\n"; else; ; end ~}}
-         {{-  end ~}}
-         );
+        return _{{ context.EntityModel.CodeCamelCase }}Manager.UpdateAsync(
+            input.Id
+        {{-  for prop in context.EntityModel.Properties -}}
+          {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
+            input.{{ prop.Code }}
+          {{- if for.last; "\r\n"; else; ; end ~}}
+        {{-  end ~}}
+            );
     }
 
     /// <summary>
@@ -67,6 +68,6 @@ public class {{ context.EntityModel.Code }}AppService : ApplicationService, I{{ 
     /// </summary>
     public Task DeleteAsync(Delete{{ context.EntityModel.Code }}Input input)
     {
-        return  _{{ context.EntityModel.CodeCamelCase }}Manager.DeleteAsync(input.Id);
+        return _{{ context.EntityModel.CodeCamelCase }}Manager.DeleteAsync(input.Id);
     }          
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Application/{{projectName}}ApplicationAutoMapperProfile.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Application/{{projectName}}ApplicationAutoMapperProfile.txt
@@ -1,15 +1,15 @@
-﻿using  AutoMapper;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
-using  {{ context.Project.NameSpace }}.Application.Contracts;
+﻿using AutoMapper;
+using {{ context.Project.NameSpace }}.Domain.Shared;
+using {{ context.Project.NameSpace }}.Application.Contracts;
 
 namespace {{ context.Project.NameSpace }}.Application;
 
-public class {{ context.Project.ProjectName }}DomainAutoMapperProfile : Profile 
+public partial class {{ context.Project.ProjectName }}DomainAutoMapperProfile : Profile 
 {
     public {{ context.Project.ProjectName }}DomainAutoMapperProfile()
     {
-       {{~ for model in context.AllEntityModels ~}}
-         CreateMap<{{ model.Code}}Dto, Page{{ model.Code}}Output>();
-       {{~ end ~}}
+      {{~ for model in context.AllEntityModels ~}}
+        CreateMap<{{ model.Code}}Dto, Page{{ model.Code}}Output>();
+      {{~ end ~}}
     }
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Create{{aggregateCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Create{{aggregateCode}}Input.txt
@@ -1,31 +1,31 @@
-using  System;
-using  System.ComponentModel.DataAnnotations;
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using System;
+using System.ComponentModel.DataAnnotations;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Application.Contracts;
 
 /// <summary>
 /// 创建{{ context.EntityModel.Description }}
 /// </summary>
-public class Create{{ context.EntityModel.Code }}Input
+public partial class Create{{ context.EntityModel.Code }}Input
 {
-        {{~ for prop in context.EntityModel.Properties ~}}
-            {{~ if prop.IsEnum ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.EnumType.Code }} {{ prop.Code }} { get;  set; }
-            {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }} {{ prop.Code }} { get; set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
         {{~ if prop.IsRequired ~}}
-        [Required(ErrorMessage = "{{prop.Description}}不能为空")]
-        public {{ prop.DataType.Code }} {{ prop.Code }} { get;  set; }
-            {{~ else ~}}
-        public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get;  set; }            
-            {{~ end ~}}
-            {{~ end ~}}
-       {{~ end ~}}          
+    [Required(ErrorMessage = "{{prop.Description}}不能为空")]
+    public {{ prop.DataType.Code }} {{ prop.Code }} { get; set; }
+        {{~ else ~}}
+        public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }            
+        {{~ end ~}}
+      {{~ end ~}}
+    {{~ end ~}}          
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Create{{entityCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Create{{entityCode}}Input.txt
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
+
+namespace {{ context.Project.NameSpace }}.Application.Contracts;
+
+/// <summary>
+/// 创建{{ context.EntityModel.Description }}
+/// </summary>
+public partial class Create{{ context.EntityModel.Code }}Input
+{
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }} {{ prop.Code }} { get; set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+        {{~ if prop.IsRequired ~}}
+    [Required(ErrorMessage = "{{prop.Description}}不能为空")]
+    public {{ prop.DataType.Code }} {{ prop.Code }} { get; set; }
+        {{~ else ~}}
+        public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }            
+        {{~ end ~}}
+      {{~ end ~}}
+    {{~ end ~}}          
+}

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Delete{{aggregateCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Delete{{aggregateCode}}Input.txt
@@ -1,15 +1,15 @@
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Application.Contracts;
 
 /// <summary>
 /// 删除{{ context.EntityModel.Description }}
 /// </summary>
-public class Delete{{ context.EntityModel.Code }}Input
+public partial class Delete{{ context.EntityModel.Code }}Input
 {
-       /// <summary>
-       /// {{ context.EntityModel.Description }}Id
-       /// </summary>
-       public Guid Id { get; set; }
+    /// <summary>
+    /// {{ context.EntityModel.Description }}Id
+    /// </summary>
+    public Guid Id { get; set; }
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Delete{{entityCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Delete{{entityCode}}Input.txt
@@ -1,0 +1,15 @@
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
+
+namespace {{ context.Project.NameSpace }}.Application.Contracts;
+
+/// <summary>
+/// 删除{{ context.EntityModel.Description }}
+/// </summary>
+public partial class Delete{{ context.EntityModel.Code }}Input
+{
+    /// <summary>
+    /// {{ context.EntityModel.Description }}Id
+    /// </summary>
+    public Guid Id { get; set; }
+}

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/I{{aggregateCode}}AppService.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/I{{aggregateCode}}AppService.txt
@@ -1,20 +1,19 @@
-using  Volo.Abp.Application.Services;
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using Volo.Abp.Application.Services;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Application.Contracts;
-
 
 /// <summary>
 /// {{ context.EntityModel.Description }}
 /// </summary>
-public interface I{{ context.EntityModel.Code }}AppService : IApplicationService
+public partial interface I{{ context.EntityModel.Code }}AppService : IApplicationService
 {
     /// <summary>
     /// 分页查询{{ context.EntityModel.Description }}
     /// </summary>
     Task<PagedResultDto<Page{{ context.EntityModel.Code }}Output>> PageAsync(Page{{ context.EntityModel.Code }}Input input);
-    
+
     /// <summary>
     /// 创建{{ context.EntityModel.Description }}
     /// </summary>    

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/I{{aggregateCode}}AppService.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/I{{aggregateCode}}AppService.txt
@@ -1,3 +1,4 @@
+using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using {{ context.Project.NameSpace }}.Domain;
 using {{ context.Project.NameSpace }}.Domain.Shared;

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Input.txt
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using Lion.AbpPro.Core;
 using {{ context.Project.NameSpace }}.Domain;
 using {{ context.Project.NameSpace }}.Domain.Shared;
 

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Input.txt
@@ -1,14 +1,14 @@
-using  System;
-using  System.ComponentModel.DataAnnotations;
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using System;
+using System.ComponentModel.DataAnnotations;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Application.Contracts;
 
 /// <summary>
-/// 创建{{ context.EntityModel.Description }}
+/// 分页查询{{ context.EntityModel.Description }}输入
 /// </summary>
-public class Page{{ context.EntityModel.Code }}Input : PagingBase
+public partial class Page{{ context.EntityModel.Code }}Input : PagingBase
 {
 
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Output.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Output.txt
@@ -1,34 +1,34 @@
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Application.Contracts;
 
 /// <summary>
-/// 创建{{ context.EntityModel.Description }}
+/// 分页查询{{ context.EntityModel.Description }}输出
 /// </summary>
-public class Page{{ context.EntityModel.Code }}Output
+public partial class Page{{ context.EntityModel.Code }}Output
 {
-       /// <summary>
-       /// {{ context.EntityModel.Description }}Id
-       /// </summary>
-       public Guid Id { get; set; }
+    /// <summary>
+    /// {{ context.EntityModel.Description }}Id
+    /// </summary>
+    public Guid Id { get; set; }
 
-        {{~ for prop in context.EntityModel.Properties ~}}
-            {{~ if prop.IsEnum ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.EnumType.Code }} {{ prop.Code }} { get;  set; }
-            {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get;  set; }
-            {{~ end ~}}
-       {{~ end ~}}  
-       
-        /// <summary>
-        /// 创建时间
-        /// </summary>       
-        public DateTime CreationTime { get; set; }     
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }} {{ prop.Code }} { get; set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }
+      {{~ end ~}}
+    {{~ end ~}}  
+ 
+    /// <summary>
+    /// 创建时间
+    /// </summary>       
+    public DateTime CreationTime { get; set; }     
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{entityCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{entityCode}}Input.txt
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using Lion.AbpPro.Core;
 using {{ context.Project.NameSpace }}.Domain;
 using {{ context.Project.NameSpace }}.Domain.Shared;
 

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{entityCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{entityCode}}Input.txt
@@ -1,0 +1,14 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
+
+namespace {{ context.Project.NameSpace }}.Application.Contracts;
+
+/// <summary>
+/// 分页查询{{ context.EntityModel.Description }}输入
+/// </summary>
+public partial class Page{{ context.EntityModel.Code }}Input : PagingBase
+{
+
+}

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{entityCode}}Output.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Page{{entityCode}}Output.txt
@@ -1,0 +1,34 @@
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
+
+namespace {{ context.Project.NameSpace }}.Application.Contracts;
+
+/// <summary>
+/// 分页查询{{ context.EntityModel.Description }}输出
+/// </summary>
+public partial class Page{{ context.EntityModel.Code }}Output
+{
+    /// <summary>
+    /// {{ context.EntityModel.Description }}Id
+    /// </summary>
+    public Guid Id { get; set; }
+
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }} {{ prop.Code }} { get; set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }
+      {{~ end ~}}
+    {{~ end ~}}  
+ 
+    /// <summary>
+    /// 创建时间
+    /// </summary>       
+    public DateTime CreationTime { get; set; }     
+}

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Update{{aggregateCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Update{{aggregateCode}}Input.txt
@@ -1,36 +1,36 @@
-using  System;
-using  System.ComponentModel.DataAnnotations;
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using System;
+using System.ComponentModel.DataAnnotations;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Application.Contracts;
 
 /// <summary>
-/// 删除{{ context.EntityModel.Description }}
+/// 更新{{ context.EntityModel.Description }}
 /// </summary>
-public class Update{{ context.EntityModel.Code }}Input
+public partial class Update{{ context.EntityModel.Code }}Input
 {
-       /// <summary>
-       /// {{ context.EntityModel.Description }}Id
-       /// </summary>
-       public Guid Id { get; set; }
-       
-        {{~ for prop in context.EntityModel.Properties ~}}
-            {{~ if prop.IsEnum ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.EnumType.Code }} {{ prop.Code }} { get;  set; }
-            {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
+    /// <summary>
+    /// {{ context.EntityModel.Description }}Id
+    /// </summary>
+    public Guid Id { get; set; }
+
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }} {{ prop.Code }} { get; set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
         {{~ if prop.IsRequired ~}}
-        [Required(ErrorMessage = "{{prop.Description}}不能为空")]
-        public {{ prop.DataType.Code }} {{ prop.Code }} { get;  set; }
-            {{~ else ~}}
-        public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get;  set; }            
-            {{~ end ~}}
-            {{~ end ~}}
-       {{~ end ~}}     
+    [Required(ErrorMessage = "{{prop.Description}}不能为空")]
+    public {{ prop.DataType.Code }} {{ prop.Code }} { get; set; }
+        {{~ else ~}}
+    public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }            
+        {{~ end ~}}
+      {{~ end ~}}
+    {{~ end ~}}     
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Update{{entityCode}}Input.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/ApplicationContracts/Update{{entityCode}}Input.txt
@@ -1,0 +1,36 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
+
+namespace {{ context.Project.NameSpace }}.Application.Contracts;
+
+/// <summary>
+/// 更新{{ context.EntityModel.Description }}
+/// </summary>
+public partial class Update{{ context.EntityModel.Code }}Input
+{
+    /// <summary>
+    /// {{ context.EntityModel.Description }}Id
+    /// </summary>
+    public Guid Id { get; set; }
+
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }} {{ prop.Code }} { get; set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+        {{~ if prop.IsRequired ~}}
+    [Required(ErrorMessage = "{{prop.Description}}不能为空")]
+    public {{ prop.DataType.Code }} {{ prop.Code }} { get; set; }
+        {{~ else ~}}
+    public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }            
+        {{~ end ~}}
+      {{~ end ~}}
+    {{~ end ~}}     
+}

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Controller/{{aggregateCode}}Controller.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Controller/{{aggregateCode}}Controller.txt
@@ -1,11 +1,11 @@
-using  Microsoft.AspNetCore.Mvc;
-using  Swashbuckle.AspNetCore.Annotations;
-using  {{ context.Project.NameSpace }}.Application.Contracts;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using {{ context.Project.NameSpace }}.Application.Contracts;
 
-namespace {{ context.Project.NameSpace }}.Controller;
+namespace {{ context.Project.NameSpace }}.Controllers;
 
 [Route("{{ context.EntityModel.AggregateCodePluralized }}")]
-public class {{ context.EntityModel.AggregateCode }}Controller : AbpController, I{{ context.EntityModel.AggregateCode }}AppService
+public partial class {{ context.EntityModel.AggregateCode }}Controller : AbpController, I{{ context.EntityModel.AggregateCode }}AppService
 {
     private readonly I{{ context.EntityModel.AggregateCode }}AppService _{{ context.EntityModel.AggregateCodeCamelCase }}AppService;
 

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Controller/{{aggregateCode}}Controller.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Controller/{{aggregateCode}}Controller.txt
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
+using Volo.Abp.Application.Dtos;
 using {{ context.Project.NameSpace }}.Application.Contracts;
 
 namespace {{ context.Project.NameSpace }}.Controllers;

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/I{{aggregateCode}}Repository.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/I{{aggregateCode}}Repository.txt
@@ -1,9 +1,9 @@
-using  Volo.Abp.Domain.Repositories;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using Volo.Abp.Domain.Repositories;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Domain;
 
-public interface I{{ context.EntityModel.Code }}Repository : IBasicRepository<{{ context.EntityModel.Code }}, Guid>
+public partial interface I{{ context.EntityModel.Code }}Repository : IBasicRepository<{{ context.EntityModel.Code }}, Guid>
 {
     Task<List<{{ context.EntityModel.Code }}>> GetListAsync(int maxResultCount = 10, int skipCount = 0);
 

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/{{aggregateCode}}.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/{{aggregateCode}}.txt
@@ -1,117 +1,117 @@
-using  Lion.AbpPro.Core;
-using  Volo.Abp;
-using  Volo.Abp.Domain.Entities.Auditing;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using Lion.AbpPro.Core;
+using Volo.Abp;
+using Volo.Abp.Domain.Entities.Auditing;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Domain;
 
 /// <summary>
 /// {{ context.EntityModel.Description }}
 /// </summary>
-public class {{ context.EntityModel.Code }} : {{ if context.EntityModel.IsRoot;  " FullAuditedAggregateRoot<Guid>"; else; " FullAuditedEntity<Guid>"; end }}
+public partial class {{ context.EntityModel.Code }} : {{ if context.EntityModel.IsRoot;  "FullAuditedAggregateRoot<Guid>"; else; "FullAuditedEntity<Guid>"; end }}
 {
-        private {{ context.EntityModel.Code }}()
-        {
-        {{~ for prop in context.EntityModel.EntityModels ~}}
-            {{~ if  prop.RelationalType == 20 ~}}
-            {{ prop.CodePluralized }} = new List<{{ prop.Code }}>();
-            {{~ end ~}}
-        {{~ end ~}}
-        }
- 
-               
-        public {{ context.EntityModel.Code }}(
-            Guid id
-            {{-  for prop in context.EntityModel.Properties -}}
-            {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
-            {{- if prop.IsEnum ~}}
-            {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-           	{{- else ~}}
-            {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-            {{- end ~}}
-            {{- if for.last; "\r\n"; else; ; end ~}}
-            {{-  end ~}}
+    private {{ context.EntityModel.Code }}()
+    {
+    {{~ for prop in context.EntityModel.EntityModels ~}}
+      {{~ if  prop.RelationalType == 20 ~}}
+        {{ prop.CodePluralized }} = new List<{{ prop.Code }}>();
+      {{~ end ~}}
+    {{~ end ~}}
+    }
+
+              
+    public {{ context.EntityModel.Code }}(
+        Guid id
+        {{-  for prop in context.EntityModel.Properties -}}
+        {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
+        {{- if prop.IsEnum ~}}
+        {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- else ~}}
+        {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- end ~}}
+        {{- if for.last; "\r\n"; else; ; end ~}}
+        {{-  end ~}}
         ) : base(id)
-        {
-             {{~  for prop in context.EntityModel.Properties ~}}
-             Set{{ prop.Code }}({{prop.CodeCamelCase}});
-             {{~  end ~}}
-        }
+    {
+        {{~  for prop in context.EntityModel.Properties ~}}
+        Set{{ prop.Code }}({{prop.CodeCamelCase}});
+        {{~  end ~}}
+    }
         
-        {{~ for prop in context.EntityModel.Properties ~}}
-            {{~ if prop.IsEnum ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.Code }} { get; private set; }
-            {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; private set; }
-            {{~ end ~}}
-       {{~ end ~}}
-    
-      {{~ for prop in context.EntityModel.EntityModels ~}}
-        {{~ if  prop.RelationalType == 10 ~}}
-        /// <summary>
-        /// {{ prop.Description }} 一对一
-        /// </summary>
-        public {{ prop.Code }} {{ prop.CodePluralized }}  { get; private set; } 
-          {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}  一对多
-        /// </summary>
-        public List<{{ prop.Code }}> {{ prop.CodePluralized }}  { get; private set; }
-          {{~ end ~}}
-      {{~ end ~}}
-                    
-      {{~ for prop in context.EntityModel.Properties ~}}
+    {{~ for prop in context.EntityModel.Properties ~}}
         {{~ if prop.IsEnum ~}}
-        
-        /// <summary>
-        /// 设置{{ prop.Description }}
-        /// </summary>
-        private void Set{{ prop.Code }}({{ prop.EnumType.Code }}{{prop.Null}} {{prop.CodeCamelCase}})
-        {
-             {{ prop.Code }} = {{ prop.CodeCamelCase }};
-        }
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.Code }} { get; private set; }
         {{~ else ~}}
-        
-        /// <summary>
-        /// 设置{{ prop.Description }}
-        /// </summary>        
-        private void Set{{ prop.Code }}({{ prop.DataType.Code }}{{prop.Null}} {{prop.CodeCamelCase}})
-        {
-            {{~ if prop.DataType.Code=="string" ~}}
-                {{~ if prop.IsRequired ~}}
-            Guard.NotNullOrWhiteSpace({{prop.CodeCamelCase}},nameof({{prop.CodeCamelCase}}), ,{{prop.MaxLength}}, {{prop.MinLength}});
-                {{~ else ~}}
-            Guard.Length({{prop.CodeCamelCase}},nameof({{prop.CodeCamelCase}}),{{prop.MaxLength}},{{prop.MinLength}});
-                {{~ end ~}}
-            {{~ end ~}}
-            {{ prop.Code }} = {{ prop.CodeCamelCase }};
-        }     
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; private set; }
         {{~ end ~}}
+    {{~ end ~}}
+
+    {{~ for prop in context.EntityModel.EntityModels ~}}
+    {{~ if  prop.RelationalType == 10 ~}}
+    /// <summary>
+    /// {{ prop.Description }} 一对一
+    /// </summary>
+    public {{ prop.Code }} {{ prop.CodePluralized }} { get; private set; } 
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}  一对多
+    /// </summary>
+    public List<{{ prop.Code }}> {{ prop.CodePluralized }} { get; private set; }
       {{~ end ~}}
+    {{~ end ~}}
+
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+
+    /// <summary>
+    /// 设置{{ prop.Description }}
+    /// </summary>
+    private void Set{{ prop.Code }}({{ prop.EnumType.Code }}{{prop.Null}} {{prop.CodeCamelCase}})
+    {
+        {{ prop.Code }} = {{ prop.CodeCamelCase }};
+    }
+      {{~ else ~}}
+
+    /// <summary>
+    /// 设置{{ prop.Description }}
+    /// </summary>        
+    private void Set{{ prop.Code }}({{ prop.DataType.Code }}{{prop.Null}} {{prop.CodeCamelCase}})
+    {
+        {{~ if prop.DataType.Code=="string" ~}}
+            {{~ if prop.IsRequired ~}}
+        Guard.NotNullOrWhiteSpace({{prop.CodeCamelCase}}, nameof({{prop.CodeCamelCase}}), {{prop.MaxLength}}, {{prop.MinLength}});
+            {{~ else ~}}
+        Guard.Length({{prop.CodeCamelCase}}, nameof({{prop.CodeCamelCase}}), {{prop.MaxLength}}, {{prop.MinLength}});
+            {{~ end ~}}
+        {{~ end ~}}
+        {{ prop.Code }} = {{ prop.CodeCamelCase }};
+    }     
+      {{~ end ~}}
+    {{~ end ~}}
       
-        /// <summary>
-        /// 更新{{ context.EntityModel.Description }}
-        /// </summary> 
-        public void Update(
-            {{-  for prop in context.EntityModel.Properties -}}
-            {{- if for.first;  "\r\n"; else; ",\r\n"; end ~}}
-            {{- if prop.IsEnum ~}}
-            {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-           	{{- else ~}}
-            {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-            {{- end ~}}
-            {{- if for.last; "\r\n"; else; ; end ~}}
-            {{-  end ~}}
-        )
-        {
-           {{~ for prop in context.EntityModel.Properties ~}}
-             Set{{ prop.Code }}({{prop.CodeCamelCase}});
-           {{~ end ~}}
-        }
+    /// <summary>
+    /// 更新{{ context.EntityModel.Description }}
+    /// </summary> 
+    public void Update(
+        {{-  for prop in context.EntityModel.Properties -}}
+        {{- if for.first;  "\r\n"; else; ",\r\n"; end ~}}
+        {{- if prop.IsEnum ~}}
+        {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- else ~}}
+        {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- end ~}}
+        {{- if for.last; "\r\n"; else; ; end ~}}
+        {{-  end ~}}
+    )
+    {
+        {{~ for prop in context.EntityModel.Properties ~}}
+        Set{{ prop.Code }}({{prop.CodeCamelCase}});
+        {{~ end ~}}
+    }
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/{{aggregateCode}}Manager.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/{{aggregateCode}}Manager.txt
@@ -1,84 +1,84 @@
-using  Volo.Abp;
-using  Volo.Abp.Domain.Services;
-using  Volo.Abp.ObjectMapping;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using Volo.Abp;
+using Volo.Abp.Domain.Services;
+using Volo.Abp.ObjectMapping;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Domain;
 
-public class {{ context.EntityModel.Code }}Manager : DomainService
+public partial class {{ context.EntityModel.Code }}Manager : DomainService
 {
-      private readonly I{{ context.EntityModel.Code }}Repository _{{ context.EntityModel.CodeCamelCase }}Repository;
-      private readonly IObjectMapper _objectMapper;
-      
-      public {{ context.EntityModel.Code }}Manager(I{{ context.EntityModel.Code }}Repository {{ context.EntityModel.CodeCamelCase }}Repository,IObjectMapper objectMapper)
-      {
-          _{{ context.EntityModel.CodeCamelCase }}Repository = {{ context.EntityModel.CodeCamelCase }}Repository;
-          _objectMapper = objectMapper;
-      }
-      
-       public async Task<List<{{ context.EntityModel.Code }}Dto>> GetListAsync(int maxResultCount = 10, int skipCount = 0)
-       {
-           var list = await  _{{ context.EntityModel.CodeCamelCase }}Repository.GetListAsync(maxResultCount, skipCount);
-           return ObjectMapper.Map<List<{{ context.EntityModel.Code }}>, List<{{ context.EntityModel.Code }}Dto>>(list);
-       }
-   
-       public async Task<long> GetCountAsync()
-       {
-           return await  _{{ context.EntityModel.CodeCamelCase }}Repository.GetCountAsync();
-       }
-       
-        /// <summary>
-        /// 创建{{ context.EntityModel.Description }}
-        /// </summary>
-        public async Task<{{ context.EntityModel.Code }}Dto> CreateAsync(
-            Guid id
-            {{-  for prop in context.EntityModel.Properties -}}
-             {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
-             {{- if prop.IsEnum ~}}
-            {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-             {{- else ~}}
-            {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-             {{- end ~}}
-            {{- if for.last; "\r\n"; else; ; end ~}}
-            {{-  end ~}}
-        )
-        {   
-            var entity = new {{ context.EntityModel.Code }}(id, {{- for prop in context.EntityModel.Properties -}}{{- if for.first;  ""; else; ","; end ~}}{{ prop.CodeCamelCase }}{{- if for.last; ""; else; ; end -}}{{- end ~}});
-            entity = await  _{{ context.EntityModel.CodeCamelCase }}Repository.InsertAsync(entity);
-            return _objectMapper.Map<{{ context.EntityModel.Code }}, {{ context.EntityModel.Code }}Dto>(entity);            
-        }   
-        
-        /// <summary>
-        /// 更新{{ context.EntityModel.Description }}
-        /// </summary>
-        public async Task<{{ context.EntityModel.Code }}Dto> UpdateAsync(
-            Guid id
-            {{-  for prop in context.EntityModel.Properties -}}
-             {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
-             {{- if prop.IsEnum ~}}
-            {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-             {{- else ~}}
-            {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-             {{- end ~}}
-           {{- if for.last; "\r\n"; else; ; end ~}}
-            {{-  end ~}}
-        )
-        {
-            var entity = await  _{{ context.EntityModel.CodeCamelCase }}Repository.FindAsync(id);
-            if (entity == null) throw new UserFriendlyException($"{{ context.EntityModel.Description }}不存在");
-            entity.Update({{- for prop in context.EntityModel.Properties -}}{{- if for.first;  ""; else; ","; end ~}}{{ prop.CodeCamelCase }}{{- if for.last; ""; else; ; end -}}{{- end ~}});
-            entity = await  _{{ context.EntityModel.CodeCamelCase }}Repository.UpdateAsync(entity);
-            return _objectMapper.Map<{{ context.EntityModel.Code }}, {{ context.EntityModel.Code }}Dto>(entity);            
-        }     
+    private readonly I{{ context.EntityModel.Code }}Repository _{{ context.EntityModel.CodeCamelCase }}Repository;
+    private readonly IObjectMapper _objectMapper;
 
-        /// <summary>
-        /// 删除{{ context.EntityModel.Description }}
-        /// </summary>
-        public async Task DeleteAsync(Guid id)
-        {
-            var entity = await  _{{ context.EntityModel.CodeCamelCase }}Repository.FindAsync(id);
-            if (entity == null) throw new UserFriendlyException($"{{ context.EntityModel.Description }}不存在");
-            await  _{{ context.EntityModel.CodeCamelCase }}Repository.DeleteAsync(entity);          
-        }         
-                         
+    public {{ context.EntityModel.Code }}Manager(I{{ context.EntityModel.Code }}Repository {{ context.EntityModel.CodeCamelCase }}Repository, IObjectMapper objectMapper)
+    {
+        _{{ context.EntityModel.CodeCamelCase }}Repository = {{ context.EntityModel.CodeCamelCase }}Repository;
+        _objectMapper = objectMapper;
+    }
+
+    public async Task<List<{{ context.EntityModel.Code }}Dto>> GetListAsync(int maxResultCount = 10, int skipCount = 0)
+    {
+        var list = await _{{ context.EntityModel.CodeCamelCase }}Repository.GetListAsync(maxResultCount, skipCount);
+        return _objectMapper.Map<List<{{ context.EntityModel.Code }}>, List<{{ context.EntityModel.Code }}Dto>>(list);
+    }
+
+    public async Task<long> GetCountAsync()
+    {
+        return await _{{ context.EntityModel.CodeCamelCase }}Repository.GetCountAsync();
+    }
+
+    /// <summary>
+    /// 创建{{ context.EntityModel.Description }}
+    /// </summary>
+    public async Task<{{ context.EntityModel.Code }}Dto> CreateAsync(
+        Guid id
+      {{-  for prop in context.EntityModel.Properties -}}
+        {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
+        {{- if prop.IsEnum ~}}
+        {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- else ~}}
+        {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- end ~}}
+        {{- if for.last; "\r\n"; else; ; end ~}}
+      {{-  end ~}}
+        )
+    {   
+        var entity = new {{ context.EntityModel.Code }}(id,{{- for prop in context.EntityModel.Properties -}}{{- if for.first;  " "; else; ", "; end ~}}{{ prop.CodeCamelCase }}{{- if for.last; ""; else; ; end -}}{{- end ~}});
+        entity = await _{{ context.EntityModel.CodeCamelCase }}Repository.InsertAsync(entity);
+        return _objectMapper.Map<{{ context.EntityModel.Code }}, {{ context.EntityModel.Code }}Dto>(entity);            
+    }   
+
+    /// <summary>
+    /// 更新{{ context.EntityModel.Description }}
+    /// </summary>
+    public async Task<{{ context.EntityModel.Code }}Dto> UpdateAsync(
+        Guid id
+      {{-  for prop in context.EntityModel.Properties -}}
+        {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
+        {{- if prop.IsEnum ~}}
+        {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- else ~}}
+        {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- end ~}}
+        {{- if for.last; "\r\n"; else; ; end ~}}
+      {{-  end ~}}
+        )
+    {
+        var entity = await _{{ context.EntityModel.CodeCamelCase }}Repository.FindAsync(id);
+        if (entity == null) throw new UserFriendlyException($"{{ context.EntityModel.Description }}不存在");
+        entity.Update({{- for prop in context.EntityModel.Properties -}}{{- if for.first;  ""; else; ", "; end ~}}{{ prop.CodeCamelCase }}{{- if for.last; ""; else; ; end -}}{{- end ~}});
+        entity = await _{{ context.EntityModel.CodeCamelCase }}Repository.UpdateAsync(entity);
+        return _objectMapper.Map<{{ context.EntityModel.Code }}, {{ context.EntityModel.Code }}Dto>(entity);            
+    }     
+
+    /// <summary>
+    /// 删除{{ context.EntityModel.Description }}
+    /// </summary>
+    public async Task DeleteAsync(Guid id)
+    {
+        var entity = await _{{ context.EntityModel.CodeCamelCase }}Repository.FindAsync(id);
+        if (entity == null) throw new UserFriendlyException($"{{ context.EntityModel.Description }}不存在");
+        await _{{ context.EntityModel.CodeCamelCase }}Repository.DeleteAsync(entity);          
+    }
+    
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/{{entityCode}}.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/{{entityCode}}.txt
@@ -1,97 +1,97 @@
-using  Lion.AbpPro.Core;
-using  Volo.Abp;
-using  Volo.Abp.Domain.Entities.Auditing;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using Lion.AbpPro.Core;
+using Volo.Abp;
+using Volo.Abp.Domain.Entities.Auditing;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Domain;
 
 /// <summary>
 /// {{ context.EntityModel.Description }}
 /// </summary>
-public class {{ context.EntityModel.Code }} : {{ if context.EntityModel.IsRoot;  " FullAuditedEntity<Guid>"; else; " FullAuditedEntity<Guid>"; end }}
+public partial class {{ context.EntityModel.Code }} : {{ if context.EntityModel.IsRoot;  " FullAuditedEntity<Guid>"; else; " FullAuditedEntity<Guid>"; end }}
 {
-        private {{ context.EntityModel.Code }}()
-        {
-        {{~ for prop in context.EntityModel.EntityModels ~}}
-            {{~ if  prop.RelationalType == 20 ~}}
-            {{ prop.CodePluralized }} = new List<{{ prop.Code }}>();
-            {{~ end ~}}
+    private {{ context.EntityModel.Code }}()
+    {
+    {{~ for prop in context.EntityModel.EntityModels ~}}
+        {{~ if  prop.RelationalType == 20 ~}}
+        {{ prop.CodePluralized }} = new List<{{ prop.Code }}>();
         {{~ end ~}}
-        }
- 
-               
-        public {{ context.EntityModel.Code }}(
-            Guid id
-            {{-  for prop in context.EntityModel.Properties -}}
-             {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
-             {{- if prop.IsEnum ~}}
-            {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-             {{- else ~}}
-            {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
-             {{- end ~}}
-           {{- if for.last; "\r\n"; else; ; end ~}}
-            {{-  end ~}}
+    {{~ end ~}}
+    }
+
+
+    public {{ context.EntityModel.Code }}(
+        Guid id
+      {{-  for prop in context.EntityModel.Properties -}}
+        {{- if for.first;  ",\r\n"; else; ",\r\n"; end ~}}
+        {{- if prop.IsEnum ~}}
+        {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- else ~}}
+        {{ prop.DataType.Code }}{{prop.Null}} {{ prop.CodeCamelCase }}
+        {{- end ~}}
+        {{- if for.last; "\r\n"; else; ; end ~}}
+      {{-  end ~}}
         ) : base(id)
-        {
-             {{~  for prop in context.EntityModel.Properties ~}}
-             Set{{ prop.Code }}({{prop.CodeCamelCase}});
-             {{~  end ~}}
-        }
+    {
+      {{~  for prop in context.EntityModel.Properties ~}}
+        Set{{ prop.Code }}({{prop.CodeCamelCase}});
+      {{~  end ~}}
+    }
         
-        {{~ for prop in context.EntityModel.Properties ~}}
-            {{~ if prop.IsEnum ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.Code }} { get; private set; }
-            {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; private set; }
-            {{~ end ~}}
-       {{~ end ~}}
-    
-      {{~ for prop in context.EntityModel.EntityModels ~}}
-        {{~ if  prop.RelationalType == 10 ~}}
-        /// <summary>
-        /// {{ prop.Description }} 一对一
-        /// </summary>
-        public {{ prop.Code }} {{ prop.CodePluralized }}  { get; private set; }
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.Code }} { get; private set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; private set; }
+      {{~ end ~}}
+    {{~ end ~}}
+
+    {{~ for prop in context.EntityModel.EntityModels ~}}
+      {{~ if  prop.RelationalType == 10 ~}}
+    /// <summary>
+    /// {{ prop.Description }} 一对一
+    /// </summary>
+    public {{ prop.Code }} {{ prop.CodePluralized }} { get; private set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}  一对多
+    /// </summary>
+    public List<{{ prop.Code }}> {{ prop.CodePluralized }} { get; private set; }
+      {{~ end ~}}
+    {{~ end ~}}
+
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+
+    /// <summary>
+    /// 设置{{ prop.Description }}
+    /// </summary>
+    private void Set{{ prop.Code }}({{ prop.EnumType.Code }}{{prop.Null}} {{prop.CodeCamelCase}})
+    {
+        {{ prop.Code }} = {{ prop.CodeCamelCase }};
+    }
+      {{~ else ~}}
+
+    /// <summary>
+    /// 设置{{ prop.Description }}
+    /// </summary>        
+    private void Set{{ prop.Code }}({{ prop.DataType.Code }}{{prop.Null}} {{prop.CodeCamelCase}})
+    {
+        {{~ if prop.DataType.Code=="string" ~}}
+          {{~ if prop.IsRequired ~}}
+        Guard.NotNullOrWhiteSpace({{prop.CodeCamelCase}}, nameof({{prop.CodeCamelCase}}), {{prop.MaxLength}}, {{prop.MinLength}});
           {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}  一对多
-        /// </summary>
-        public List<{{ prop.Code }}> {{ prop.CodePluralized }}  { get; private set; }
+        Guard.Length({{prop.CodeCamelCase}}, nameof({{prop.CodeCamelCase}}), {{prop.MaxLength}}, {{prop.MinLength}});
           {{~ end ~}}
-      {{~ end ~}}
-                    
-      {{~ for prop in context.EntityModel.Properties ~}}
-        {{~ if prop.IsEnum ~}}
-        
-        /// <summary>
-        /// 设置{{ prop.Description }}
-        /// </summary>
-        private void Set{{ prop.Code }}({{ prop.EnumType.Code }}{{prop.Null}} {{prop.CodeCamelCase}})
-        {
-             {{ prop.Code }} = {{ prop.CodeCamelCase }};
-        }
-        {{~ else ~}}
-        
-        /// <summary>
-        /// 设置{{ prop.Description }}
-        /// </summary>        
-        private void Set{{ prop.Code }}({{ prop.DataType.Code }}{{prop.Null}} {{prop.CodeCamelCase}})
-        {
-            {{~ if prop.DataType.Code=="string" ~}}
-                {{~ if prop.IsRequired ~}}
-            Guard.NotNullOrWhiteSpace({{prop.CodeCamelCase}},nameof({{prop.CodeCamelCase}}), ,{{prop.MaxLength}}, {{prop.MinLength}});
-                {{~ else ~}}
-            Guard.Length({{prop.CodeCamelCase}},nameof({{prop.CodeCamelCase}}),{{prop.MaxLength}},{{prop.MinLength}});
-                {{~ end ~}}
-            {{~ end ~}}
-            {{ prop.Code }} = {{ prop.CodeCamelCase }};
-        }      
         {{~ end ~}}
+        {{ prop.Code }} = {{ prop.CodeCamelCase }};
+    }      
       {{~ end ~}}
+    {{~ end ~}}
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/{{projectName}}DomainAutoMapperProfile.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/Domain/{{projectName}}DomainAutoMapperProfile.txt
@@ -1,15 +1,15 @@
-﻿using  AutoMapper;
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+﻿using AutoMapper;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.Domain;
 
-public class {{ context.Project.ProjectName }}DomainAutoMapperProfile :Profile 
+public partial class {{ context.Project.ProjectName }}DomainAutoMapperProfile : Profile 
 {
     public {{ context.Project.ProjectName }}DomainAutoMapperProfile()
     {
-       {{~ for model in context.AllEntityModels ~}}
-         CreateMap<{{ model.Code}}, {{ model.Code}}Dto>();
-       {{~ end ~}}
+      {{~ for model in context.AllEntityModels ~}}
+        CreateMap<{{ model.Code}}, {{ model.Code}}Dto>();
+      {{~ end ~}}
     }
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/DomainShared/{{aggregateCode}}Dto.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/DomainShared/{{aggregateCode}}Dto.txt
@@ -3,50 +3,50 @@ namespace {{ context.Project.NameSpace }}.Domain.Shared;
 /// <summary>
 /// {{ context.EntityModel.Description }}
 /// </summary>
-public class {{ context.EntityModel.Code }}Dto 
+public partial class {{ context.EntityModel.Code }}Dto 
 {
-        /// <summary>
-        /// 主键Id
-        /// </summary>
-        public Guid Id { get; set; }
-        
-        /// <summary>
-        /// 创建时间
-        /// </summary>
-        public DateTime CreationTime { get; set; }  
-              
-        {{~ for prop in context.EntityModel.Properties ~}}
-            {{~ if prop.IsEnum ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.Code }} { get;  set; }
-            {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get;  set; }
-            {{~ end ~}}
-       {{~ end ~}}
-    
-      {{~ for prop in context.EntityModel.EntityModels ~}}
-        {{~ if  prop.RelationalType == 10 ~}}
-        /// <summary>
-        /// {{ prop.Description }} 一对一
-        /// </summary>
-        public {{ prop.Code }} {{ prop.CodePluralized }}  { get;  set; } 
-          {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}  一对多
-        /// </summary>
-        public List<{{ prop.Code }}> {{ prop.CodePluralized }}  { get;  set; }
-          {{~ end ~}}
+    /// <summary>
+    /// 主键Id
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// 创建时间
+    /// </summary>
+    public DateTime CreationTime { get; set; }  
+
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }
       {{~ end ~}}
-                    
-        private const string CacheKeyFormat = "i:{0}";
-      
-        public static string CalculateCacheKey(Guid id)
-        {
-            return string.Format(CacheKeyFormat, id);
-        }
+    {{~ end ~}}
+
+    {{~ for prop in context.EntityModel.EntityModels ~}}
+      {{~ if  prop.RelationalType == 10 ~}}
+    /// <summary>
+    /// {{ prop.Description }} 一对一
+    /// </summary>
+    public {{ prop.Code }}Dto {{ prop.CodePluralized }} { get; set; } 
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}  一对多
+    /// </summary>
+    public List<{{ prop.Code }}Dto> {{ prop.CodePluralized }} { get; set; }
+      {{~ end ~}}
+    {{~ end ~}}
+
+    private const string CacheKeyFormat = "i:{0}";
+
+    public static string CalculateCacheKey(Guid id)
+    {
+        return string.Format(CacheKeyFormat, id);
+    }
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/DomainShared/{{entityCode}}Dto.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/DomainShared/{{entityCode}}Dto.txt
@@ -3,50 +3,50 @@ namespace {{ context.Project.NameSpace }}.Domain.Shared;
 /// <summary>
 /// {{ context.EntityModel.Description }}
 /// </summary>
-public class {{ context.EntityModel.Code }}Dto 
+public partial class {{ context.EntityModel.Code }}Dto 
 {
-        /// <summary>
-        /// 主键Id
-        /// </summary>
-        public Guid Id { get; set; }
-        
-        /// <summary>
-        /// 创建时间
-        /// </summary>
-        public DateTime CreationTime { get; set; }  
-        
-        {{~ for prop in context.EntityModel.Properties ~}}
-            {{~ if prop.IsEnum ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.Code }} { get;  set; }
-            {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}
-        /// </summary>
-        public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get;  set; }
-            {{~ end ~}}
-       {{~ end ~}}
-    
-      {{~ for prop in context.EntityModel.EntityModels ~}}
-        {{~ if  prop.RelationalType == 10 ~}}
-        /// <summary>
-        /// {{ prop.Description }} 一对一
-        /// </summary>
-        public {{ prop.Code }}Dto {{ prop.CodePluralized }}  { get;  set; } 
-          {{~ else ~}}
-        /// <summary>
-        /// {{ prop.Description }}  一对多
-        /// </summary>
-        public List<{{ prop.Code }}Dto> {{ prop.CodePluralized }}  { get;  set; }
-          {{~ end ~}}
+    /// <summary>
+    /// 主键Id
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// 创建时间
+    /// </summary>
+    public DateTime CreationTime { get; set; }  
+
+    {{~ for prop in context.EntityModel.Properties ~}}
+      {{~ if prop.IsEnum ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.EnumType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}
+    /// </summary>
+    public {{ prop.DataType.Code }}{{prop.Null}} {{ prop.Code }} { get; set; }
       {{~ end ~}}
-                    
-        private const string CacheKeyFormat = "i:{0}";
-      
-        public static string CalculateCacheKey(Guid id)
-        {
-            return string.Format(CacheKeyFormat, id);
-        }
+    {{~ end ~}}
+
+    {{~ for prop in context.EntityModel.EntityModels ~}}
+      {{~ if  prop.RelationalType == 10 ~}}
+    /// <summary>
+    /// {{ prop.Description }} 一对一
+    /// </summary>
+    public {{ prop.Code }}Dto {{ prop.CodePluralized }} { get; set; } 
+      {{~ else ~}}
+    /// <summary>
+    /// {{ prop.Description }}  一对多
+    /// </summary>
+    public List<{{ prop.Code }}Dto> {{ prop.CodePluralized }} { get; set; }
+      {{~ end ~}}
+    {{~ end ~}}
+
+    private const string CacheKeyFormat = "i:{0}";
+
+    public static string CalculateCacheKey(Guid id)
+    {
+        return string.Format(CacheKeyFormat, id);
+    }
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/DomainShared/{{enumCode}}.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/DomainShared/{{enumCode}}.txt
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace {{ context.Project.NameSpace }}.Domain.Shared;
 
 /// <summary>
@@ -5,7 +7,7 @@ namespace {{ context.Project.NameSpace }}.Domain.Shared;
 /// </summary>
 public enum {{ context.EnumType.Code }}
 {
-     {{~ for prop in context.EnumType.Properties ~}}
-     [Description("{{ prop.Description }}")] {{ prop.Code }} = {{ prop.Value }},
-     {{~ end ~}} 
+  {{~ for prop in context.EnumType.Properties ~}}
+    [Description("{{ prop.Description }}")] {{ prop.Code }} = {{ prop.Value }},
+  {{~ end ~}} 
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/EfCore{{aggregateCode}}QueryableExtension.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/EfCore{{aggregateCode}}QueryableExtension.txt
@@ -2,9 +2,9 @@ namespace {{ context.Project.NameSpace }}.EntityFrameworkCore;
 
 public static class EfCore{{ context.EntityModel.Code }}QueryableExtension
 {
-     public static IQueryable<{{ context.EntityModel.Code }}> IncludeDetails(this IQueryable<{{ context.EntityModel.Code }}> queryable, bool include = true)
-     {
-         if (!include) return queryable;
-         return queryable;
-     }
+    public static IQueryable<{{ context.EntityModel.Code }}> IncludeDetails(this IQueryable<{{ context.EntityModel.Code }}> queryable, bool include = true)
+    {
+        if (!include) return queryable;
+        return queryable;
+    }
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/EfCore{{aggregateCode}}Repository.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/EfCore{{aggregateCode}}Repository.txt
@@ -1,32 +1,32 @@
-using  Volo.Abp.Domain.Repositories.EntityFrameworkCore;
-using  Volo.Abp.EntityFrameworkCore;
-using  Microsoft.EntityFrameworkCore;
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
+using Volo.Abp.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.EntityFrameworkCore;
 
 /// <summary>
 /// {{ context.EntityModel.Description }} 仓储Ef core 实现
 /// </summary>
-public class EfCore{{ context.EntityModel.Code }}Repository :
+public partial class EfCore{{ context.EntityModel.Code }}Repository :
     EfCoreRepository<I{{ context.Project.ProjectName }}DbContext, {{ context.EntityModel.Code }}, Guid>,
     I{{ context.EntityModel.Code }}Repository
 {
-      public EfCore{{ context.EntityModel.Code }}Repository(IDbContextProvider<I{{ context.Project.ProjectName }}DbContext> dbContextProvider) : base(dbContextProvider)
-      {
-      }
+    public EfCore{{ context.EntityModel.Code }}Repository(IDbContextProvider<I{{ context.Project.ProjectName }}DbContext> dbContextProvider) : base(dbContextProvider)
+    {
+    }
 
-        public async Task<List<{{ context.EntityModel.Code }}>> GetListAsync(int maxResultCount = 10, int skipCount = 0)
-        {
-            return await (await GetDbSetAsync())
-                .OrderByDescending(e => e.CreationTime)
-                .PageBy(skipCount, maxResultCount)
-                .ToListAsync();
-        }
+    public async Task<List<{{ context.EntityModel.Code }}>> GetListAsync(int maxResultCount = 10, int skipCount = 0)
+    {
+        return await (await GetDbSetAsync())
+            .OrderByDescending(e => e.CreationTime)
+            .PageBy(skipCount, maxResultCount)
+            .ToListAsync();
+    }
 
-        public async Task<long> GetCountAsync()
-        {
-            return await (await GetDbSetAsync()).CountAsync();
-        }
-}    
+    public async Task<long> GetCountAsync()
+    {
+        return await (await GetDbSetAsync()).CountAsync();
+    }
+}

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/I{{projectName}}DbContext.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/I{{projectName}}DbContext.txt
@@ -1,14 +1,14 @@
-using  Microsoft.EntityFrameworkCore;
-using  Volo.Abp.Data;
-using  Volo.Abp.EntityFrameworkCore;
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using Microsoft.EntityFrameworkCore;
+using Volo.Abp.Data;
+using Volo.Abp.EntityFrameworkCore;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.EntityFrameworkCore;
 
-public interface I{{context.Project.ProjectName}}DbContext : IEfCoreDbContext
+public partial interface I{{context.Project.ProjectName}}DbContext : IEfCoreDbContext
 {
-        {{~ for model in context.AllEntityModels ~}}
-          DbSet<{{ model.Code}}> {{ model.CodePluralized}} { get; set; }
-        {{~ end ~}}
+  {{~ for model in context.AllEntityModels ~}}
+    DbSet<{{ model.Code}}> {{ model.CodePluralized}} { get; set; }
+  {{~ end ~}}
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/{{projectName}}DbContext.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/{{projectName}}DbContext.txt
@@ -1,15 +1,15 @@
-using  Microsoft.EntityFrameworkCore;
-using  Volo.Abp.Data;
-using  Volo.Abp.EntityFrameworkCore;
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using Microsoft.EntityFrameworkCore;
+using Volo.Abp.Data;
+using Volo.Abp.EntityFrameworkCore;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.EntityFrameworkCore;
 
 [ConnectionStringName("Default")]
-public class {{context.Project.ProjectName}}DbContext : AbpDbContext<{{context.Project.ProjectName}}DbContext> : I{{context.Project.ProjectName}}DbContext
+public partial class {{context.Project.ProjectName}}DbContext : AbpDbContext<{{context.Project.ProjectName}}DbContext>, I{{context.Project.ProjectName}}DbContext
 {
-     {{~ for model in context.AllEntityModels ~}}
-        public  DbSet<{{ model.Code}}> {{ model.CodePluralized}} { get; set; }
-     {{~ end ~}}
+  {{~ for model in context.AllEntityModels ~}}
+    public DbSet<{{ model.Code}}> {{ model.CodePluralized}} { get; set; }
+  {{~ end ~}}
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/{{projectName}}DbContextModelCreatingExtensions.txt
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/Standard/EntityFrameworkCore/{{projectName}}DbContextModelCreatingExtensions.txt
@@ -1,29 +1,29 @@
-using  Microsoft.EntityFrameworkCore;
-using  Volo.Abp;
-using  Volo.Abp.EntityFrameworkCore.Modeling;
-using  {{ context.Project.NameSpace }}.Domain;
-using  {{ context.Project.NameSpace }}.Domain.Shared;
+using Microsoft.EntityFrameworkCore;
+using Volo.Abp;
+using Volo.Abp.EntityFrameworkCore.Modeling;
+using {{ context.Project.NameSpace }}.Domain;
+using {{ context.Project.NameSpace }}.Domain.Shared;
 
 namespace {{ context.Project.NameSpace }}.EntityFrameworkCore;
 
-public static class {{context.Project.ProjectName}}DbContextModelCreatingExtensions
+public static partial class {{context.Project.ProjectName}}DbContextModelCreatingExtensions
 {
-   public static void Configure{{context.Project.ProjectName}}(this ModelBuilder builder)
-   {
-         Check.NotNull(builder, nameof(builder));
-         {{~ for model in context.AllEntityModels ~}}
-         builder.Entity<{{ model.Code}}>(b =>
-         {
-             b.ToTable({{context.Project.ProjectName}}DomainConsts.DbTablePrefix + nameof({{ model.Code}}).Pluralize());
-             {{~ for property in model.Properties ~}}
-             {{~ if  property.IsRequired && property.IsDataType && property.DataType.Code == "string" ~}}
-             b.Property(e => e.{{ property.Code}}).IsRequired().HasMaxLength({{ property.MaxLength}}).HasComment("{{ property.Description}}");
-             {{~ else ~}}
-             b.Property(e => e.{{ property.Code}}).HasComment("{{ property.Description}}");
-             {{~ end ~}}
-             {{~ end ~}}
-             b.ConfigureByConvention();
-         });
-         {{~ end ~}}
-   }
+    public static void Configure{{context.Project.ProjectName}}(this ModelBuilder builder)
+    {
+        Check.NotNull(builder, nameof(builder));
+        {{~ for model in context.AllEntityModels ~}}
+        builder.Entity<{{ model.Code}}>(b =>
+        {
+            b.ToTable({{context.Project.ProjectName}}DomainConsts.DbTablePrefix + nameof({{ model.Code}}).Pluralize());
+          {{~ for property in model.Properties ~}}
+            {{~ if  property.IsRequired && property.IsDataType && property.DataType.Code == "string" ~}}
+            b.Property(e => e.{{ property.Code}}).IsRequired().HasMaxLength({{ property.MaxLength}}).HasComment("{{ property.Description}}");
+            {{~ else ~}}
+            b.Property(e => e.{{ property.Code}}).HasComment("{{ property.Description}}");
+            {{~ end ~}}
+          {{~ end ~}}
+            b.ConfigureByConvention();
+        });
+        {{~ end ~}}
+    }
 }

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/StandardTemplateDataSeedConst.cs
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/StandardTemplateDataSeedConst.cs
@@ -37,24 +37,39 @@ public class StandardTemplateDataSeedConst
                 // 聚合根IApplicationService模板
                 public static string IApplicationServiceName = "I{{aggregateCode}}AppService.txt";
                 public static string IApplicationServicePath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/I{{aggregateCode}}AppService.txt";
-               
-                public static string CreateInputName = "Create{{aggregateCode}}Input.txt";
-                public static string CreateInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Create{{aggregateCode}}Input.txt";
                 
-                public static string UpdateInputName = "Update{{aggregateCode}}Input.txt";
-                public static string UpdateInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Update{{aggregateCode}}Input.txt";
+                public static string CreateAggregateCodeInputName = "Create{{aggregateCode}}Input.txt";
+                public static string CreateAggregateCodeInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Create{{aggregateCode}}Input.txt";
                 
-                public static string DeleteInputName = "Delete{{aggregateCode}}Input.txt";
-                public static string DeleteInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Delete{{aggregateCode}}Input.txt";
+                public static string UpdateAggregateCodeInputName = "Update{{aggregateCode}}Input.txt";
+                public static string UpdateAggregateCodeInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Update{{aggregateCode}}Input.txt";
                 
-                public static string PageInputName = "Page{{aggregateCode}}Input.txt";
-                public static string PageInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Input.txt";
+                public static string DeleteAggregateCodeInputName = "Delete{{aggregateCode}}Input.txt";
+                public static string DeleteAggregateCodeInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Delete{{aggregateCode}}Input.txt";
                 
-                public static string PageOutputName = "Page{{aggregateCode}}Output.txt";
-                public static string PageOutputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Output.txt";
+                public static string PageAggregateCodeInputName = "Page{{aggregateCode}}Input.txt";
+                public static string PageAggregateCodeInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Input.txt";
                 
+                public static string PageAggregateCodeOutputName = "Page{{aggregateCode}}Output.txt";
+                public static string PageAggregateCodeOutputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Page{{aggregateCode}}Output.txt";
+                
+                public static string CreateEntityCodeInputName = "Create{{entityCode}}Input.txt";
+                public static string CreateEntityCodeInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Create{{entityCode}}Input.txt";
+
+                public static string UpdateEntityCodeInputName = "Update{{entityCode}}Input.txt";
+                public static string UpdateEntityCodeInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Update{{entityCode}}Input.txt";
+
+                public static string DeleteEntityCodeInputName = "Delete{{entityCode}}Input.txt";
+                public static string DeleteEntityCodeInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Delete{{entityCode}}Input.txt";
+
+                public static string PageEntityCodeInputName = "Page{{entityCode}}Input.txt";
+                public static string PageEntityCodeInputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Page{{entityCode}}Input.txt";
+
+                public static string PageEntityCodeOutputName = "Page{{entityCode}}Output.txt";
+                public static string PageEntityCodeOutputPath = "/Lion.AbpSuite/Data/Templates/Standard/ApplicationContracts/Page{{entityCode}}Output.txt";
+
             }
-            
+
             public static class  Domain
             {
                 public static string Name = "Domain";

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/TemplateDataSeedContributor.cs
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/TemplateDataSeedContributor.cs
@@ -95,30 +95,57 @@ public class TemplateDataSeedContributor : IDataSeedContributor, ITransientDepen
             ControlType.Aggregate,
             await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.IApplicationServicePath),
             applicationContracts.Id);
+
         AddFile(templateGroup,
-            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.CreateInputName,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.CreateAggregateCodeInputName,
             ControlType.Aggregate,
-            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.CreateInputPath),
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.CreateAggregateCodeInputPath),
             applicationContracts.Id);
         AddFile(templateGroup,
-            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.UpdateInputName,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.UpdateAggregateCodeInputName,
             ControlType.Aggregate,
-            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.UpdateInputPath),
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.UpdateAggregateCodeInputPath),
             applicationContracts.Id);
         AddFile(templateGroup,
-            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.DeleteInputName,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.DeleteAggregateCodeInputName,
             ControlType.Aggregate,
-            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.DeleteInputPath),
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.DeleteAggregateCodeInputPath),
             applicationContracts.Id);
         AddFile(templateGroup,
-            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageInputName,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageAggregateCodeInputName,
             ControlType.Aggregate,
-            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageInputPath),
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageAggregateCodeInputPath),
             applicationContracts.Id);
         AddFile(templateGroup,
-            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageOutputName,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageAggregateCodeOutputName,
             ControlType.Aggregate,
-            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageOutputPath),
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageAggregateCodeOutputPath),
+            applicationContracts.Id);
+
+        AddFile(templateGroup,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.CreateEntityCodeInputName,
+            ControlType.Aggregate,
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.CreateEntityCodeInputPath),
+            applicationContracts.Id);
+        AddFile(templateGroup,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.UpdateEntityCodeInputName,
+            ControlType.Aggregate,
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.UpdateEntityCodeInputPath),
+            applicationContracts.Id);
+        AddFile(templateGroup,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.DeleteEntityCodeInputName,
+            ControlType.Aggregate,
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.DeleteEntityCodeInputPath),
+            applicationContracts.Id);
+        AddFile(templateGroup,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageEntityCodeInputName,
+            ControlType.Aggregate,
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageEntityCodeInputPath),
+            applicationContracts.Id);
+        AddFile(templateGroup,
+            StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageEntityCodeOutputName,
+            ControlType.Aggregate,
+            await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageEntityCodeOutputPath),
             applicationContracts.Id);
 
         #endregion

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/TemplateDataSeedContributor.cs
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Data/Templates/TemplateDataSeedContributor.cs
@@ -124,27 +124,27 @@ public class TemplateDataSeedContributor : IDataSeedContributor, ITransientDepen
 
         AddFile(templateGroup,
             StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.CreateEntityCodeInputName,
-            ControlType.Aggregate,
+            ControlType.Entity,
             await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.CreateEntityCodeInputPath),
             applicationContracts.Id);
         AddFile(templateGroup,
             StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.UpdateEntityCodeInputName,
-            ControlType.Aggregate,
+            ControlType.Entity,
             await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.UpdateEntityCodeInputPath),
             applicationContracts.Id);
         AddFile(templateGroup,
             StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.DeleteEntityCodeInputName,
-            ControlType.Aggregate,
+            ControlType.Entity,
             await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.DeleteEntityCodeInputPath),
             applicationContracts.Id);
         AddFile(templateGroup,
             StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageEntityCodeInputName,
-            ControlType.Aggregate,
+            ControlType.Entity,
             await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageEntityCodeInputPath),
             applicationContracts.Id);
         AddFile(templateGroup,
             StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageEntityCodeOutputName,
-            ControlType.Aggregate,
+            ControlType.Entity,
             await _fileLoader.LoadAsync(StandardTemplateDataSeedConst.AspNetCore.Src.ApplicationContracts.PageEntityCodeOutputPath),
             applicationContracts.Id);
 

--- a/aspnet-core/src/Lion.AbpSuite.Domain/Generators/GeneratorManager.cs
+++ b/aspnet-core/src/Lion.AbpSuite.Domain/Generators/GeneratorManager.cs
@@ -101,6 +101,15 @@ public class GeneratorManager : AbpSuiteDomainService
             result.Add(code);
         }
 
+        foreach (var entity in treeEntityModelContexts.EntityModels)
+        {
+            foreach (var enumType in entity.EnumTypes)
+            {
+                var code = await GeneratorCodeAsync(template, project, treeEntityModelContexts, enumType);
+                result.Add(code);
+            }
+        }
+
         return result;
     }
 


### PR DESCRIPTION
1、统一修改镜像版本为8.0；
2、由于.Net 8.0修改了默认端口为8080，所以调整Docker暴漏端口为8080；
3、修复聚合根子对象枚举未生成的问题；
4、修改默认模板输出文件缩进与vs默认缩进相同；
5、在输出文件中增加partial关键字，用于支持单类多文件，用于分离自动生成与手动编写代码；
6、修正模板中注释错误；
7、修复DomainShared中Dto中对子对象的引用错误；
8、修复缺失using引用；
9、在默认模板应用层增加实体类；